### PR TITLE
Bugfix: director endpoint

### DIFF
--- a/manifests/alerting/icingaweb2/director.pp
+++ b/manifests/alerting/icingaweb2/director.pp
@@ -23,17 +23,6 @@ class profiles::alerting::icingaweb2::director (
   String $api_host     = 'localhost',
 ) inherits profiles::alerting::icingaweb2 {
 
-  # Endpoint is needed
-  icinga2::object::endpoint {'director':
-    endpoint_name => 'director',
-    host          => 'localhost',
-    port          => '5665',
-  }
-
-  icinga2::object::zone {'director':
-    endpoints => ['director'],
-  }
-
   class {'icingaweb2::module::director':
     db_name       => $db_name,
     db_username   => $db_username,
@@ -46,11 +35,10 @@ class profiles::alerting::icingaweb2::director (
     api_host      => $api_host,
     import_schema => true,
     kickstart     => true,
-    endpoint      => 'director',
+    endpoint      => $::fqdn,
     require       => [
       Package['git'],
       Postgresql::Server::Db[$db_name],
-      Icinga2::Object::Endpoint['director'],
     ],
   }
 }

--- a/manifests/alerting/icingaweb2/director.pp
+++ b/manifests/alerting/icingaweb2/director.pp
@@ -21,6 +21,7 @@ class profiles::alerting::icingaweb2::director (
   String $api_user     = $::profiles::alerting::icingaweb2::api_user,
   String $api_password = $::profiles::alerting::icingaweb2::api_password,
   String $api_host     = 'localhost',
+  String $endpoint     = $::fqdn,
 ) inherits profiles::alerting::icingaweb2 {
 
   class {'icingaweb2::module::director':
@@ -35,7 +36,7 @@ class profiles::alerting::icingaweb2::director (
     api_host      => $api_host,
     import_schema => true,
     kickstart     => true,
-    endpoint      => $::fqdn,
+    endpoint      => $endpoint,
     require       => [
       Package['git'],
       Postgresql::Server::Db[$db_name],


### PR DESCRIPTION
The director does not need it's own endpoint, just a defined one.
Using the NodeName endpoint on the icinga2 instance from profiles::monitoring::icinga2.
This maps to the fqdn of the host if it's all on the same host, created a parameter for it so that it can be overwritten if needed.