### PR TITLE
Feature: Icinga2: Setup deep merging of the vars hash

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -24,3 +24,8 @@ lookup_options:
     merge:
       strategy: deep
       merge_hash_arrays: true
+  profiles::monitoring::icinga2::vars:
+    merge:
+      strategy: deep
+      merge_hash_arrays: true
+

--- a/manifests/monitoring/icinga2.pp
+++ b/manifests/monitoring/icinga2.pp
@@ -120,7 +120,7 @@ class profiles::monitoring::icinga2 (
       display_name => $::hostname,
       import       => ['linux-host'],
       target       => "/etc/icinga2/zones.d/${parent_zone}/${::hostname}.conf",
-      vars         => $vars,
+      vars         => lookup( 'profiles::monitoring::icinga2::vars', Hash, 'deep' ),
     }
   }
 

--- a/manifests/monitoring/icinga2.pp
+++ b/manifests/monitoring/icinga2.pp
@@ -120,7 +120,7 @@ class profiles::monitoring::icinga2 (
       display_name => $::hostname,
       import       => ['linux-host'],
       target       => "/etc/icinga2/zones.d/${parent_zone}/${::hostname}.conf",
-      vars         => lookup( 'profiles::monitoring::icinga2::vars', Hash, 'deep' ),
+      vars         => $vars,
     }
   }
 

--- a/manifests/monitoring/icinga2.pp
+++ b/manifests/monitoring/icinga2.pp
@@ -120,7 +120,7 @@ class profiles::monitoring::icinga2 (
       display_name => $::hostname,
       import       => ['linux-host'],
       target       => "/etc/icinga2/zones.d/${parent_zone}/${::hostname}.conf",
-      vars         => lookup( 'profiles::monitoring::icinga2::vars', Hash, 'deep', $vars ),
+      vars         => lookup( 'profiles::monitoring::icinga2::vars', Hash, 'deep' ),
     }
   }
 

--- a/manifests/monitoring/icinga2.pp
+++ b/manifests/monitoring/icinga2.pp
@@ -120,7 +120,7 @@ class profiles::monitoring::icinga2 (
       display_name => $::hostname,
       import       => ['linux-host'],
       target       => "/etc/icinga2/zones.d/${parent_zone}/${::hostname}.conf",
-      vars         => lookup( 'profiles::monitoring::icinga2::vars', Hash, 'deep' ),
+      vars         => lookup( 'profiles::monitoring::icinga2::vars', Hash, 'deep', $vars ),
     }
   }
 


### PR DESCRIPTION
Allow for the profiles::monitoring::icinga2::vars parameter passed to the host object to use deep merging.
This way hiera can be used for setting defaults.

Signed-off-by: bjanssens <bjanssens@inuits.eu>