### PR TITLE
Fix name of class to be included

### DIFF
--- a/manifests/security.pp
+++ b/manifests/security.pp
@@ -8,6 +8,6 @@ class profiles::security (
   Boolean $selinux = false,
 ) {
   if $selinux {
-    class { '::profiles::selinux': }
+    class { '::profiles::security::selinux': }
   }
 }


### PR DESCRIPTION
Allow profiles::security::selinux to be included when $selinux == true.
Fixes #28 