### PR TITLE
Feature icingaweb allow other auth

### DIFF
--- a/manifests/alerting/icingaweb2.pp
+++ b/manifests/alerting/icingaweb2.pp
@@ -15,6 +15,7 @@
 # @param ido_database_user     Ido user.
 # @param manage_repo           Manage icinga2 web repos.
 # @param modules               Include other icingaweb2 modules.
+# @param roles                 Additional roles.
 class profiles::alerting::icingaweb2 (
   String $api_password = 'icinga',
   String $api_user = 'root',
@@ -28,6 +29,7 @@ class profiles::alerting::icingaweb2 (
   String $ido_database_user = 'icinga2',
   Boolean $manage_repo = false,
   Array $modules = [],
+  Hash $roles = {},
 ) {
   class {'icingaweb2':
     manage_repo   => $manage_repo,
@@ -61,6 +63,10 @@ class profiles::alerting::icingaweb2 (
       ensure_packages( ['git'], { 'ensure' => 'present' })
       class { "::profiles::alerting::icingaweb2::${module}":; }
     }
+  }
+
+  if ( $roles!= {} ) {
+    create_resources( ::icingaweb2::config::role, $roles )
   }
 
 }

--- a/manifests/alerting/icingaweb2/auth.pp
+++ b/manifests/alerting/icingaweb2/auth.pp
@@ -1,0 +1,33 @@
+#
+#
+#
+class profiles::alerting::icingaweb2::auth (
+  String $bind_dn,
+  String $bind_pw,
+  String $hostname,
+  String $ldap_userclass,
+  String $root_dn,
+  String $auth_type      = 'ldap',
+  String $encryption     = 'none',
+  String $ldap_filter    = '',
+  Integer $port           = 389,
+) {
+  ::icingaweb2::config::resource{'ldap-resource':
+    type            => $auth_type,
+    host            => $hostname,
+    port            => $port,
+    ldap_encryption => $encryption,
+    ldap_root_dn    => $root_dn,
+    ldap_bind_dn    => $bind_dn,
+    ldap_bind_pw    => $bind_pw
+  }
+
+  ::icingaweb2::config::authmethod {'ldap-auth':
+    backend                  => $auth_type,
+    resource                 => 'ldap-resource',
+    ldap_user_class          => $ldap_userclass,
+    ldap_filter              => $ldap_filter,
+    ldap_user_name_attribute => 'uid',
+    order                    => '01',
+  }
+}


### PR DESCRIPTION
This allows ldap to be used as a backend for icingaweb2 authentication.
It is added as a module analog to grafana.

For multiuser environment having extra roles defined in hiera is a must.
This allows the icingaweb2 class to take a roles hash which it then uses to generate the additional roles.

Signed-off-by: bjanssens <bjanssens@inuits.eu>