### PR TITLE
Runtime: Php: Cachetool: Add unless to prevent download every time

### DIFF
--- a/manifests/runtime/php/cachetool.pp
+++ b/manifests/runtime/php/cachetool.pp
@@ -35,6 +35,7 @@ class profiles::runtime::php::cachetool (
         group       => $group,
         source      => $phar_source,
         timeout     => 0,
+        unless      => "test -f ${install_dir}/cachetool",
       }
     }
     default: {


### PR DESCRIPTION
Upon using the wget module it will keep fetching the file if there is no unless passed.
This commit add the unless with the correct test to preform.

Signed-off-by: bjanssens <bjanssens@inuits.eu>