### PR TITLE
Monitoring: Icinga2: Allow generating more then one api user

### DIFF
--- a/manifests/monitoring/icinga2.pp
+++ b/manifests/monitoring/icinga2.pp
@@ -7,6 +7,7 @@
 # @param api_password      Api password.
 # @param api_pki           Cypher to use for api certs.
 # @param api_user          Api user.
+# @param api_users         Hash of api users to generate.
 # @param checkcommands     List of checks
 # @param client            Is this a icinga client.
 # @param confd             Include conf.d directory or specify your own.
@@ -36,6 +37,7 @@ class profiles::monitoring::icinga2 (
   String $api_password = 'icinga',
   String $api_pki = 'puppet',
   String $api_user = 'root',
+  Hash $api_users = undef,
   Boolean $client = true,
   Variant[Boolean,String] $confd = false,
   String $database_host = '127.0.0.1',
@@ -145,6 +147,15 @@ class profiles::monitoring::icinga2 (
       password    => $api_password,
       permissions => [ '*' ],
       target      => "/etc/icinga2/zones.d/${parent_zone}/api-users.conf",
+    }
+
+    if $api_users and $api_users != {} {
+      $api_users.each | $user, $opts | {
+        ::icinga2::object::apiuser { $user:
+          *      => $opts,
+          target => "/etc/icinga2/zones.d/${parent_zone}/api-users.conf",
+        }
+      }
     }
 
     file { ['/etc/icinga2/zones.d/master',


### PR DESCRIPTION
This commit allows for generating more then the one 'root' api user for icinga.
This can then be used to create api users for dashboards and other monitoring tools.

Signed-off-by: bjanssens <bjanssens@inuits.eu>