### PR TITLE
Monitoring: Bugfix: Icinga2: api_users hash is optional

### DIFF
--- a/manifests/monitoring/icinga2.pp
+++ b/manifests/monitoring/icinga2.pp
@@ -37,7 +37,7 @@ class profiles::monitoring::icinga2 (
   String $api_password = 'icinga',
   String $api_pki = 'puppet',
   String $api_user = 'root',
-  Hash $api_users = undef,
+  Optional[Hash] $api_users = undef,
   Boolean $client = true,
   Variant[Boolean,String] $confd = false,
   String $database_host = '127.0.0.1',


### PR DESCRIPTION
Current code will generate an error message as undef is not a hash.
This patch fixes this by adding Optional[] around the Hash.

Signed-off-by: bjanssens <bjanssens@inuits.eu>