### PR TITLE
Database: Postgresql: Allow additional hba rules for postgres

### DIFF
--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -9,13 +9,15 @@
 # @param listen_address (String) list address
 # @param manage_repo (Boolean) Manage repository.
 # @param version (String) Version to install.
+# @param hba_rules (Hash) Extra hba rules to setup.
 class profiles::database::postgresql (
-  $databases               = {},
-  $encoding                = 'UTF-8',
-  $ip_mask_allow_all_users = '127.0.0.1/32',
-  $listen_address          = 'localhost',
-  $manage_repo             = false,
-  $version                 = '10',
+  $databases                = {},
+  $encoding                 = 'UTF-8',
+  $ip_mask_allow_all_users  = '127.0.0.1/32',
+  $listen_address           = 'localhost',
+  $manage_repo              = false,
+  $version                  = '10',
+  Optional[Hash] $hba_rules = undef,
 ) {
   class { '::postgresql::globals':
     encoding            => $encoding,
@@ -32,5 +34,9 @@ class profiles::database::postgresql (
 
   profiles::bootstrap::firewall::entry { '200 allow pgsql':
     port => 5432,
+  }
+
+  if $hba_rules and $hba_rules != {} {
+    create_resources(postgresql::server::pg_hba_rule, $hba_rules, { 'postgresql_version' => $version })
   }
 }


### PR DESCRIPTION
This commit allows to generate additional hba rules if connections from outside the host are wanted.
They can be added in hiera as this:
```
profiles::database::postgresql::hba_rules:
  'remote_access':
    type: host
    database: all
    user: icinga2
    auth_method: md5
    address: 10.10.20.0/24
```

Signed-off-by: bjanssens <bjanssens@inuits.eu>