### PR TITLE
Monitoring: Icinga2: Template for templates.conf

### DIFF
--- a/manifests/monitoring/icinga2.pp
+++ b/manifests/monitoring/icinga2.pp
@@ -60,6 +60,12 @@ class profiles::monitoring::icinga2 (
   Hash $timeperiods = {},
   Hash $usergroups = {},
   Hash $vars = {},
+  String $generic_host_check_attempts = '5',
+  String $generic_host_check_interval = '1m',
+  String $generic_host_retry_interval = '30s',
+  String $generic_service_check_attempts = '3',
+  String $generic_service_check_interval = '1m',
+  String $generic_service_retry_interval = '30s',
 ) inherits profiles::monitoring::icinga2::params {
   if $server {
     $constants = {
@@ -192,11 +198,11 @@ class profiles::monitoring::icinga2 (
 
     # Static config files
     file { '/etc/icinga2/zones.d/global-templates/templates.conf':
-      ensure => file,
-      owner  => 'icinga',
-      group  => 'icinga',
-      mode   => '0640',
-      source => 'puppet:///modules/profiles/monitoring/icinga2/templates.conf',
+      ensure  => file,
+      owner   => 'icinga',
+      group   => 'icinga',
+      mode    => '0640',
+      content => template('profiles/monitoring/icinga2/template.conf.erb'),
     }
 
     profiles::bootstrap::firewall::entry { '200 allow icinga':

--- a/templates/monitoring/icinga2/templates.conf.erb
+++ b/templates/monitoring/icinga2/templates.conf.erb
@@ -1,7 +1,7 @@
 template Host "generic-host" {
-  max_check_attempts = 3
-  check_interval = 1m
-  retry_interval = 30s
+  max_check_attempts = <%= @generic_host_check_attempts %>
+  check_interval = <%= @generic_host_check_interval %>
+  retry_interval = <%= @generic_host_retry_interval %>
 
   check_command = "hostalive"
   vars.slack_notifications = "enabled"
@@ -17,9 +17,9 @@ template Host "linux-host" {
 }
 
 template Service "generic-service" {
-  max_check_attempts = 5
-  check_interval = 1m
-  retry_interval = 30s
+  max_check_attempts = <%= @generic_service_check_attempts %>
+  check_interval = <%= @generic_service_check_interval %>
+  retry_interval = <%= @generic_service_retry_interval %>
 
   vars.slack_notifications = "enabled"
 }


### PR DESCRIPTION
This commit adds parameters to set the different intervals for the generic_service and host objects.
Allowing for a greater check_interval on both.

Signed-off-by: bjanssens <bjanssens@inuits.eu>