### PR TITLE
orchestration/consul: Consul dns firewall needs UDP and TCP

### DIFF
--- a/manifests/orchestration/consul.pp
+++ b/manifests/orchestration/consul.pp
@@ -57,8 +57,13 @@ class profiles::orchestration::consul (
   profiles::bootstrap::firewall::entry { '100 allow consul serf LAN':
     port => 8301,
   }
-  profiles::bootstrap::firewall::entry { '100 allow consul DNS':
-    port => 8600,
+  profiles::bootstrap::firewall::entry { '100 allow consul DNS TCP':
+    port     => 8600,
+    protocol => 'tcp'
+  }
+  profiles::bootstrap::firewall::entry { '100 allow consul DNS UDP':
+    port     => 8600,
+    protocol => 'udp',
   }
 
   create_resources(::consul::check, $checks)


### PR DESCRIPTION
As title says, it's impossible to do a DNS lookup like `active.vault.service.consul` if port 53 UDP is not allowed by the firewall.