### PR TITLE
Manage the notifications for the global-templates.

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -105,6 +105,28 @@ profiles::monitoring::icinga2::templates:
         - DowntimeRemoved
       period: 24x7
 
+profiles::monitoring::icinga2::notifications:
+  mail-icingaadmin-host:
+    import:
+      - mail-host-notification
+    user_groups: host.vars.notification.mail.groups
+    users: host.vars.notification.mail.users
+    assign:
+      - host.vars.notification.mail
+    target: /etc/icinga2/zones.d/global-templates/notifications.conf
+    apply: true
+  mail-icingaadmin-service:
+    import:
+      - mail-service-notification
+    user_groups: host.vars.notification.mail.groups
+    users: host.vars.notification.mail.users
+    assign:
+      - host.vars.notification.mail
+    apply_target: Service
+    apply: true
+    target: /etc/icinga2/zones.d/global-templates/notifications.conf
+
+
 profiles::monitoring::icinga2::services:
   linux_icinga:
     import:

--- a/manifests/monitoring/icinga2.pp
+++ b/manifests/monitoring/icinga2.pp
@@ -32,6 +32,8 @@
 # @param usergroups                     User groups
 # @param vars                           Icinga vars.
 # @param templates                      Templates.
+# @param notifications                  Notification objects to generate.
+# @param fragments                      Custom configuration fragments.
 class profiles::monitoring::icinga2 (
   Hash $parent_endpoints,
   Optional[String] $api_endpoint = undef,
@@ -64,6 +66,8 @@ class profiles::monitoring::icinga2 (
   Hash $usergroups = {},
   Hash $vars = {},
   Hash $templates = {},
+  Hash $notifications = {},
+  Hash $fragments = {},
 ) inherits profiles::monitoring::icinga2::params {
   if $server {
     $constants = {
@@ -194,6 +198,9 @@ class profiles::monitoring::icinga2 (
     ensure_resources( ::icinga2::object::service, $services )
     ensure_resources( ::icinga2::object::timeperiod, $timeperiods )
     ensure_resources( ::icinga2::object::usergroup, $usergroups )
+    ensure_resources( ::icinga2::object::notification, $notifications )
+    ensure_resources( ::icinga2::object::fragment, $fragments )
+
     $templates.each | $object_type, $object_configs | {
       $_default_template_params = {
         'target'   => '/etc/icinga2/zones.d/global-templates/templates.conf',


### PR DESCRIPTION
This change allows for users to define the notification objects in hiera.
The default notifications that can be found in '/etc/icinga2/conf.d/notifcations.conf' where added in the profiles module data.

As these notifications can be highly specific to the organization, also allow to add custom fragments to them via the fragments hash.

Signed-off-by: bjanssens <bjanssens@inuits.eu>