### PR TITLE
Monitoring: Icinga2: Bugfix: Fragment is not an object but a config type

### DIFF
--- a/manifests/monitoring/icinga2.pp
+++ b/manifests/monitoring/icinga2.pp
@@ -199,7 +199,7 @@ class profiles::monitoring::icinga2 (
     ensure_resources( ::icinga2::object::timeperiod, $timeperiods )
     ensure_resources( ::icinga2::object::usergroup, $usergroups )
     ensure_resources( ::icinga2::object::notification, $notifications )
-    ensure_resources( ::icinga2::object::fragment, $fragments )
+    ensure_resources( ::icinga2::config::fragment, $fragments )
 
     $templates.each | $object_type, $object_configs | {
       $_default_template_params = {


### PR DESCRIPTION
Bugfix as the fragment define is located in the config directory in the upstream icinga2 module.

Signed-off-by: bjanssens <bjanssens@inuits.eu>