### PR TITLE
Feature alerting resources

### DIFF
--- a/manifests/alerting/icingaweb2.pp
+++ b/manifests/alerting/icingaweb2.pp
@@ -35,6 +35,7 @@ class profiles::alerting::icingaweb2 (
   Array $sd_service_tags = ['metrics'],
   Array $modules = [],
   Hash $roles = {},
+  Hash $resources = {},
 ) {
   class {'icingaweb2':
     manage_repo   => $manage_repo,
@@ -73,6 +74,9 @@ class profiles::alerting::icingaweb2 (
 
   if ( $roles!= {} ) {
     create_resources( ::icingaweb2::config::role, $roles )
+  }
+  if ( $resources != {} ) {
+    create_resources( ::icingaweb2::config::resource, $resources )
   }
 
   if $manage_database {


### PR DESCRIPTION
This commit allows to pass additional configuration via a hash for icingaweb2 modules. For example defining a database resource for the reporting module to use:
```yaml
501 profiles::alerting::icingaweb2::resources:
502   pgsql-reporting:
503     type: db
504     db_type: pgsql
505     host: localhost
506     port: 5432
507     db_name: reporting
508     db_username: reporting
509     db_password: reporting
510     db_charset: utf8
```