### PR TITLE
Feature website nginx vhost params

### DIFF
--- a/manifests/website/nginx.pp
+++ b/manifests/website/nginx.pp
@@ -18,8 +18,7 @@
 # @param streams                 Set(s) of streams.
 # @param vhosts                  Set(s) of vhost to create
 # @param vhost_packages          Packages to manage that contain vhosts files.
-# @param custom_defined_type     Boolean to use the custom defined type in profiles, set to false to directly use
-#                                the nginx module provided server type.
+# @param upstream_defined_type   Boolean to directly use the upstream nginx server type.
 class profiles::website::nginx (
   String $client_body_buffer_size = '1k',
   String $client_max_body_size = '1k',
@@ -31,7 +30,7 @@ class profiles::website::nginx (
   Hash $streams = {},
   Hash $vhosts = {},
   Hash $vhost_packages = {},
-  Boolean $custom_defined_type = true,
+  Boolean $upstream_defined_type = false,
 ) {
   class { '::nginx':
     client_body_buffer_size => $client_body_buffer_size,
@@ -56,12 +55,12 @@ class profiles::website::nginx (
     tag        => 'do_b',
   }
 
-  if $custom_defined_type {
-    create_resources( '::profiles::website::nginx::vhost', $vhosts, $resource_defaults )
-    Package<| tag == 'do_a' |> -> ::Profiles::Website::Nginx::Vhost<| tag == 'do_b' |>
-  } else {
+  if $upstream_defined_type {
     create_resources( 'nginx::resource::server', $vhosts, $resource_defaults )
     Package<| tag == 'do_a' |> -> Nginx::Resource::Server<| tag == 'do_b' |>
+  } else {
+    create_resources( '::profiles::website::nginx::vhost', $vhosts, $resource_defaults )
+    Package<| tag == 'do_a' |> -> ::Profiles::Website::Nginx::Vhost<| tag == 'do_b' |>
   }
 
   create_resources( '::profiles::website::nginx::proxy', $proxies, $resource_defaults )

--- a/manifests/website/nginx/vhost.pp
+++ b/manifests/website/nginx/vhost.pp
@@ -17,13 +17,25 @@ define profiles::website::nginx::vhost (
   Hash $vhost_params = {},
 ) {
 
+  if has_key($vhost_params, 'proxy') {
+    $_vhost_params = {
+      fastcgi       => $fastcgi,
+      fastcgi_index => $fastcgi_index,
+      listen_port   => $port,
+      server_name   => $public_name,
+    } + $vhost_params
+  } else {
+    $_vhost_params = {
+      fastcgi       => $fastcgi,
+      fastcgi_index => $fastcgi_index,
+      listen_port   => $port,
+      server_name   => $public_name,
+      www_root      => $www_root,
+    } + $vhost_params
+  }
+
   ::nginx::resource::server { $name:
-    fastcgi       => $fastcgi,
-    fastcgi_index => $fastcgi_index,
-    listen_port   => $port,
-    server_name   => $public_name,
-    www_root      => $www_root,
-    *             => $vhost_params,
+    *             => $_vhost_params,
   }
 
   if $manage_firewall_entry {

--- a/manifests/website/nginx/vhost.pp
+++ b/manifests/website/nginx/vhost.pp
@@ -14,7 +14,7 @@ define profiles::website::nginx::vhost (
   Array[String] $public_name = [$name],
   String $sd_service_name = $name,
   Array $sd_service_tags = [],
-  Hahs $vhost_params = {},
+  Hash $vhost_params = {},
 ) {
 
   ::nginx::resource::server { $name:

--- a/manifests/website/nginx/vhost.pp
+++ b/manifests/website/nginx/vhost.pp
@@ -14,6 +14,7 @@ define profiles::website::nginx::vhost (
   Array[String] $public_name = [$name],
   String $sd_service_name = $name,
   Array $sd_service_tags = [],
+  Hahs $vhost_params = {},
 ) {
 
   ::nginx::resource::server { $name:
@@ -22,6 +23,7 @@ define profiles::website::nginx::vhost (
     listen_port   => $port,
     server_name   => $public_name,
     www_root      => $www_root,
+    *             => $vhost_params,
   }
 
   if $manage_firewall_entry {

--- a/manifests/website/nginx/vhost.pp
+++ b/manifests/website/nginx/vhost.pp
@@ -14,28 +14,14 @@ define profiles::website::nginx::vhost (
   Array[String] $public_name = [$name],
   String $sd_service_name = $name,
   Array $sd_service_tags = [],
-  Hash $vhost_params = {},
 ) {
 
-  if has_key($vhost_params, 'proxy') {
-    $_vhost_params = {
-      fastcgi       => $fastcgi,
-      fastcgi_index => $fastcgi_index,
-      listen_port   => $port,
-      server_name   => $public_name,
-    } + $vhost_params
-  } else {
-    $_vhost_params = {
-      fastcgi       => $fastcgi,
-      fastcgi_index => $fastcgi_index,
-      listen_port   => $port,
-      server_name   => $public_name,
-      www_root      => $www_root,
-    } + $vhost_params
-  }
-
   ::nginx::resource::server { $name:
-    *             => $_vhost_params,
+    fastcgi       => $fastcgi,
+    fastcgi_index => $fastcgi_index,
+    listen_port   => $port,
+    server_name   => $public_name,
+    www_root      => $www_root,
   }
 
   if $manage_firewall_entry {


### PR DESCRIPTION
Using the custom defined types for creating vhosts in nginx is good for easy setups, sadly it would mean that building more complex vhosts is now impossible. First iteration tried to add logic to build a config hash to pass to the nginx::resource::server type but this would grow very complex. Instead opted to add a flag so one can toggle between more generic vhost config generated by the profiles module itself or straight use the nginx module defined type so one can pass more options. By default it will still use the type defined within the profiles to not break setups that have switched over.