### PR TITLE
Carbon: Add support for carbon-c-relay cache for graphite setup

### DIFF
--- a/manifests/metrics/carbon.pp
+++ b/manifests/metrics/carbon.pp
@@ -83,7 +83,7 @@ class profiles::metrics::carbon (
       }
     }
     default: {
-      fail( "Unsupported relay type ${replay_type}" )
+      fail( "Unsupported relay type ${relay_type}" )
     }
   }
 }

--- a/manifests/metrics/carbon.pp
+++ b/manifests/metrics/carbon.pp
@@ -23,6 +23,7 @@
 class profiles::metrics::carbon (
   Boolean $carbon_cache_enabled = true,
   Hash $carbon_caches = {},
+  Hash $carbon_c_relay = {},
   String $carbon_ensure = present,
   String $carbon_type = 'carbon',
   String $line_receiver_interface = '0.0.0.0',
@@ -70,6 +71,19 @@ class profiles::metrics::carbon (
     }
     default: {
       fail( "Unsupported carbon type ${carbon_type}" )
+    }
+  }
+
+  case $relay_type {
+    'carbon': {}
+    'carbon-c-relay': {
+      class { 'carbon_c_relay':
+        clusters => $carbon_c_relay['clusters'],
+        matches  => $carbon_c_relay['matches'],
+      }
+    }
+    default: {
+      fail( "Unsupported relay type ${replay_type}" )
     }
   }
 }


### PR DESCRIPTION
This allows for setting up the carbon-c-relay (https://github.com/grobian/carbon-c-relay) as alternative to the python implementation.
It uses this puppet module to manage it: https://github.com/bartjanssens92/puppet-carbon_c_relay

Signed-off-by: bjanssens <bjanssens@inuits.eu>