### PR TITLE
Feature foreman proxy allow nonpuppet proxies

### DIFF
--- a/manifests/puppet/foreman_proxy.pp
+++ b/manifests/puppet/foreman_proxy.pp
@@ -16,7 +16,9 @@ class profiles::puppet::foreman_proxy (
   String$oauth_consumer_key = 'secret',
   String $oauth_consumer_secret = 'secret',
   String $protocol = 'https',
+  Boolean $puppet = true,
   Boolean $puppetca = false,
+  Boolean $tftp = false,
   String $version = 'present',
 ) {
   if $protocol == 'https' {
@@ -42,13 +44,13 @@ class profiles::puppet::foreman_proxy (
     manage_sudoersd       => $manage_sudoersd,
     puppetca              => $puppetca,
     puppetca_listen_on    => $protocol,
-    puppet                => true,
+    puppet                => $puppet,
     puppet_listen_on      => $protocol,
     registered_name       => $::fqdn,
     registered_proxy_url  => "${protocol}://${::fqdn}:${port}",
     ssl                   => $ssl,
     ssl_port              => 8443,
-    tftp                  => false,
+    tftp                  => $tftp,
     trusted_hosts         => [$::fqdn, $foreman_host],
     version               => $version,
   }

--- a/manifests/puppet/foreman_proxy.pp
+++ b/manifests/puppet/foreman_proxy.pp
@@ -12,6 +12,9 @@
 # @param version               What version should be installed.
 class profiles::puppet::foreman_proxy (
   String $foreman_host = 'foreman',
+  Boolean $manage_bmc = false,
+  Boolean $manage_dhcp = false,
+  Boolean $manage_dns = false,
   Boolean $manage_sudoersd = true,
   String$oauth_consumer_key = 'secret',
   String $oauth_consumer_secret = 'secret',
@@ -31,9 +34,9 @@ class profiles::puppet::foreman_proxy (
     $ssl  = false
   }
   class { '::foreman_proxy':
-    bmc                   => false,
-    dhcp                  => false,
-    dns                   => false,
+    bmc                   => $manage_bmc,
+    dhcp                  => $manage_dhcp,
+    dns                   => $manage_dns,
     foreman_base_url      => "${protocol}://${foreman_host}",
     http                  => $http,
     http_port             => $port,


### PR DESCRIPTION
This pull request allows more flexibility when using the foreman_proxy class. Now it can be used to setup any kind of foreman-proxy instead of a proxy that also manages puppet.