### PR TITLE
Feature make icingaweb2 host independable

### DIFF
--- a/manifests/alerting/icingaweb2.pp
+++ b/manifests/alerting/icingaweb2.pp
@@ -19,6 +19,7 @@
 class profiles::alerting::icingaweb2 (
   String $api_password = 'icinga',
   String $api_user = 'root',
+  String $api_endpoint = 'localhost',
   String $database_grant = 'all',
   String $database_host = '127.0.0.1',
   String $database_name = 'icingaweb2',
@@ -51,10 +52,11 @@ class profiles::alerting::icingaweb2 (
 
   class {'icingaweb2::module::monitoring':
     commandtransports => {
-      icinga2 => {
+      icinga2         => {
         transport => 'api',
         username  => $api_user,
         password  => $api_password,
+        hostname  => $api_endpoint,
       }
     },
     ido_type          => 'pgsql',

--- a/manifests/alerting/icingaweb2.pp
+++ b/manifests/alerting/icingaweb2.pp
@@ -56,7 +56,7 @@ class profiles::alerting::icingaweb2 (
         transport => 'api',
         username  => $api_user,
         password  => $api_password,
-        hostname  => $api_endpoint,
+        host      => $api_endpoint,
       }
     },
     ido_type          => 'pgsql',

--- a/manifests/alerting/icingaweb2.pp
+++ b/manifests/alerting/icingaweb2.pp
@@ -52,7 +52,7 @@ class profiles::alerting::icingaweb2 (
 
   class {'icingaweb2::module::monitoring':
     commandtransports => {
-      icinga2         => {
+      icinga2 => {
         transport => 'api',
         username  => $api_user,
         password  => $api_password,


### PR DESCRIPTION
In the end, all that is needed to be able to move the icingaweb2 to a separate node is to add a *one* parameter to point the api in the right direction.