### PR TITLE
Bugfix: Icinga2: Actually pass the manage_repo parameter to the icinga class

### DIFF
--- a/manifests/dashboard/statping.pp
+++ b/manifests/dashboard/statping.pp
@@ -7,18 +7,18 @@
 class profiles::dashboard::statping (
   String $archive_source = 'https://github.com/statping/statping/releases/download/v0.90.74/statping-linux-amd64.tar.gz',
   Hash $config = {
-    'connection' => 'sqlite3',
-    'language' => 'en',
-    'allow_reports' => 'true',
-    'location' => '/etc/statping',
-    'sqlfile' => '/etc/statping/statping.db',
-    'disable_http' => 'false',
-    'demo_mode' => 'false',
-    'disable_logs' => 'false',
-    'use_assets' => 'false',
-    'sample_data' => 'false',
-    'use_cdn' => 'false',
-    'disable_colors' => 'false',
+    'connection'     => 'sqlite3',
+    'language'       => 'en',
+    'allow_reports'  => 'true', # lint:ignore:quoted_booleans
+    'location'       => '/etc/statping',
+    'sqlfile'        => '/etc/statping/statping.db',
+    'disable_http'   => 'false', # lint:ignore:quoted_booleans
+    'demo_mode'      => 'false', # lint:ignore:quoted_booleans
+    'disable_logs'   => 'false', # lint:ignore:quoted_booleans
+    'use_assets'     => 'false', # lint:ignore:quoted_booleans
+    'sample_data'    => 'false', # lint:ignore:quoted_booleans
+    'use_cdn'        => 'false', # lint:ignore:quoted_booleans
+    'disable_colors' => 'false', # lint:ignore:quoted_booleans
   },
   String $http_addr = '127.0.0.1',
   Stdlib::Port $http_port = 8080,

--- a/manifests/monitoring/icinga2.pp
+++ b/manifests/monitoring/icinga2.pp
@@ -102,10 +102,10 @@ class profiles::monitoring::icinga2 (
   }
 
   class { '::icinga2':
-    confd       => $confd,
-    constants   => $constants,
-    features    => $features,
-    manage_repo => true,
+    confd        => $confd,
+    constants    => $constants,
+    features     => $features,
+    manage_repos => $manage_repo,
   }
 
   class { '::icinga2::feature::api':


### PR DESCRIPTION
Also update the manage_repo parameter to manage_repos as the first one is on it's way out:
```
159   if $manage_repos or $manage_repo {
160     require ::icinga::repos
161     if $manage_repo {
162       deprecation('manage_repo', 'manage_repo is deprecated and will be replaced by manage_repos in the future.')
163     }
164   }

```
Signed-off-by: bjanssens <bjanssens@inuits.eu>