### PR TITLE
Nginx: Vhost: Allow passing SSL to configure certs

### DIFF
--- a/manifests/website/nginx/vhost.pp
+++ b/manifests/website/nginx/vhost.pp
@@ -14,7 +14,22 @@ define profiles::website::nginx::vhost (
   Array[Stdlib::Host] $public_name = [$name],
   String $sd_service_name = $name,
   Array $sd_service_tags = [],
+  Boolean $ssl = false,
+  Optional[String] $ssl_cert = undef,
+  Optional[String] $ssl_key = undef,
 ) {
+
+  case $ss {
+    true: {
+      $_ssl_options = {
+        'ssl'      => $ssl,
+        'ssl_only' => $ssl,
+        'ssl_cert' => $ssl_cert,
+        'ssl_key'  => $ssl_key,
+      }
+    }
+    default: { $_ssl_options = { 'ssl' => $ssl } }
+  }
 
   ::nginx::resource::server { $name:
     fastcgi       => $fastcgi,
@@ -22,6 +37,7 @@ define profiles::website::nginx::vhost (
     listen_port   => $port,
     server_name   => $public_name,
     www_root      => $www_root,
+    *             => $_ssl_options,
   }
 
   if $manage_firewall_entry {

--- a/manifests/website/nginx/vhost.pp
+++ b/manifests/website/nginx/vhost.pp
@@ -19,7 +19,7 @@ define profiles::website::nginx::vhost (
   Optional[String] $ssl_key = undef,
 ) {
 
-  case $ss {
+  case $ssl {
     true: {
       $_ssl_options = {
         'ssl'      => $ssl,


### PR DESCRIPTION
This commit adds very minor keys to manage ssl on a defined vhost. For when the class is used without a proxy that would handle the SSL termination.

Signed-off-by: bjanssens <bjanssens@inuits.eu>